### PR TITLE
Fix main module path

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,8 +2,8 @@
   "name": "fetch-sync",
   "version": "2.0.0",
   "description": "Proxy fetch requests through the Background Sync API",
-  "main": "lib/client/index.js",
-  "jsnext:main": "src/client/index.js",
+  "main": "lib/client.js",
+  "jsnext:main": "src/client.js",
   "author": "Sam Gluck <sdgluck@gmail.com>",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
The installed library does not have `lib/client/index.js`. The path is rather `lib/client.js`.

![image](https://user-images.githubusercontent.com/1745854/28636848-86e24926-720d-11e7-8f8f-5b9f6e331430.png)

![image](https://user-images.githubusercontent.com/1745854/28636853-8cce641e-720d-11e7-8138-1ff4994b9e4f.png)
